### PR TITLE
ci: Unbreak gh release call

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -229,4 +229,11 @@ jobs:
         PRERELEASE_SWITCH: ${{ case(fromJSON(needs.build.outputs.prerelease), '--prerelease', '') }}
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GH_REPO: ${{ github.repository }}
-      run: gh release create --title "${RELEASE_TITLE}" --notes-file release_notes.md "${PRERELEASE_SWITCH}" "${GITHUB_REF_NAME}" dist/*
+      run: |
+        set -euo pipefail
+        args=( --title "$RELEASE_TITLE" --notes-file release_notes.md  )
+        if [[ -n "$PRERELEASE_SWITCH" ]]; then
+            args+=( "$PRERELEASE_SWITCH" )
+        fi
+        echo "::debug::Executing gh release create $(printf '%q ' "${args[@]}")$GITHUB_REF_NAME dist/*"
+        gh release create "${args[@]}" "${GITHUB_REF_NAME}" dist/*


### PR DESCRIPTION
Handle optional arguments with a bash array as this is otherwise handled like an empty tag name on the command-line for `gh release create`.
