### PR TITLE
ci: check building dists during linting

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,8 @@
     "bot"
   ],
   "extends": [
-    "config:best-practices"
+    "config:best-practices",
+    "customManagers:githubActionsVersions"
   ],
   "packageRules": [
     {

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -9,6 +9,8 @@ on:
 
 env:
   FORCE_COLOR: 1
+  # renovate: datasource=pypi depName=twine
+  TWINE_VERSION: 7.0.0
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -66,6 +68,11 @@ jobs:
       uses: jakebailey/pyright-action@8ec14b5cfe41f26e5f41686a31eb6012758217ef # v3.0.2
       with:
         version: PATH
+
+    - name: Check packaging
+      run: |
+        uv build
+        uvx twine@"$TWINE_VERSION" check --strict dist/*
 
   tests:
     strategy:
@@ -179,9 +186,6 @@ jobs:
       run: |
         uv build
         rm -f dist/.gitignore  # get-releasenotes can't handle non-dist files here
-
-    - name: Check build
-      run: uvx twine check --strict dist/*
 
     - name: Prepare Release Note
       id: note


### PR DESCRIPTION
Run `uv build` and `twine check` during linting so we can catch build issues much earlier. Have renovate manage the version used.
